### PR TITLE
Updated Makefile, added initial commit script, improved README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,13 @@ help:
 .PHONY: bootstrap
 bootstrap: ## Bootstrap local environment for first use
 	make git-hooks
+	pip3 install --user Jinja2 PyYAML boto3
+	@{ \
+		export AWS_PROFILE=$(aws_profile); \
+		export AWS_REGION=$(aws_region); \
+		python3 bootstrap_terraform.py; \
+	}
+	terraform fmt -recursive
 
 .PHONY: git-hooks
 git-hooks: ## Set up hooks in .git/hooks
@@ -22,3 +29,19 @@ git-hooks: ## Set up hooks in .git/hooks
 			ln -s -f ../../.githooks/$${hook} $${HOOK_DIR}/$${hook}; \
 		done \
 	}
+
+.PHONY: initial-commit
+initial-commit: ## Rename template files
+	./initial-commit.sh
+
+.PHONY: terraform-init
+terraform-init: ## Run `terraform init` from repo root
+	terraform init terraform/deploy/
+
+.PHONY: terraform-plan
+terraform-plan: ## Run `terraform plan` from repo root
+	terraform plan -var-file=terraform/deploy/terraform.tfvars terraform/deploy/
+
+.PHONY: terraform-apply
+terraform-apply: ## Run `terraform apply` from repo root
+	terraform apply -var-file=terraform/deploy/terraform.tfvars terraform/deploy/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # dataworks-repo-template
 Template repository for DataWorks GitHub
+
+### Initialisation steps
+Welcome to your new DataWorks GitHub repository.
+
+Please run:  
+`make initial-commit`
+to being using your repository.  
+
+The `initial-commit` will create a PR adding the `dataworks-githooks` submodule to the `.githooks` folder.  For more info see: [dataworks-githooks](https://github.com/dwp/dataworks-githooks)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Welcome to your new DataWorks GitHub repository.
 
 Please run:  
 `make initial-commit`
-to being using your repository.  
+to begin using your repository.  
 
 The `initial-commit` will create a PR adding the `dataworks-githooks` submodule to the `.githooks` folder.  For more info see: [dataworks-githooks](https://github.com/dwp/dataworks-githooks)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # dataworks-repo-template
 Template repository for DataWorks GitHub
 
+This repo contains the Makefile to fit the standard pattern.
+This repo will be used as a base to create new non-Terraform repos, upon which the user runs make initial-commit, adding the githooks submodule, making the repo ready for use.
+
 ### Initialisation steps
 Welcome to your new DataWorks GitHub repository.
 

--- a/initial-commit.sh
+++ b/initial-commit.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+ORIGIN=$(git remote get-url origin)
+
+git remote set-url origin $ORIGIN
+git checkout -b initial-commit
+git submodule add https://github.com/dwp/dataworks-githooks .githooks
+make git-hooks
+
+rm initial-commit.sh
+
+git add --all
+git commit -m "Renamed pipeline to fit repository"
+git push --quiet --set-upstream origin initial-commit


### PR DESCRIPTION
Added basic pipeline for templating non-Terraform repos.

This repo contains the Makefile to fit the standard pattern.
This repo will be used as a base to create new non-Terraform repos, upon which the user runs `make initial-commit`, adding the githooks submodule,  making the repo ready for use.